### PR TITLE
fix: Change the typing of injectionDecoratorToken

### DIFF
--- a/packages/injectable/core/index.d.ts
+++ b/packages/injectable/core/index.d.ts
@@ -191,8 +191,10 @@ export const lifecycleEnum: {
 
 type RegistrationCallback = (injectable: Injectable<any, any, any>) => void;
 
-export type InjectionTargetDecorator<InjectionInstance> = {
-  decorate: (instance: InjectionInstance) => InjectionInstance;
+export type InjectionTargetDecorator<InjectionInstance, InstantiationParam> = {
+  decorate: (
+    instantiate: Instantiate<InjectionInstance, InstantiationParam>,
+  ) => Instantiate<InjectionInstance, InstantiationParam>;
 };
 
 export type InstantiationTargetDecorator<
@@ -226,7 +228,7 @@ export const createInstantiationTargetDecorator: <
 >;
 
 export const injectionDecoratorToken: InjectionToken<
-  InjectionTargetDecorator<any>,
+  InjectionTargetDecorator<unknown, unknown>,
   void
 >;
 

--- a/packages/injectable/core/index.test-d.ts
+++ b/packages/injectable/core/index.test-d.ts
@@ -11,6 +11,7 @@ import {
   lifecycleEnum,
   Instantiate,
   Injectable,
+  injectionDecoratorToken,
 } from '.';
 
 const di = createContainer('some-container');
@@ -94,6 +95,23 @@ const decoratorForParameterInjectable = getInjectable({
     }),
 
   injectionToken: instantiationDecoratorToken,
+});
+
+const decoratorForInjectionParameterInjectable = getInjectable({
+  id: 'decorator-for-parameter-injectable',
+
+  instantiate: () => ({
+    decorate: toBeDecorated => (di, param) => {
+      expectType<unknown>(param);
+      expectType<Instantiate<unknown, unknown>>(toBeDecorated);
+
+      const instance = toBeDecorated(di, param);
+
+      return instance;
+    },
+  }),
+
+  injectionToken: injectionDecoratorToken,
 });
 
 // given injectable with unspecified type for instantiation parameter, argument typing is OK


### PR DESCRIPTION
Noticed this after trying to #7 in `15.2.0` in https://github.com/lensapp/lens/pull/7437.

