### PR TITLE
feat: Allow isInjectable and isInjectionToken to be used for type narrowing

### DIFF
--- a/packages/injectable/core/index.d.ts
+++ b/packages/injectable/core/index.d.ts
@@ -349,8 +349,8 @@ export const instantiationDecoratorToken: InjectionToken<
 
 export const registrationCallbackToken: RegistrationCallback;
 export const deregistrationCallbackToken: RegistrationCallback;
-export const isInjectable: (thing: any) => boolean;
-export const isInjectionToken: (thing: any) => boolean;
+export const isInjectable: (thing: unknown) => thing is Injectable<unknown, unknown, unknown>;
+export const isInjectionToken: (thing: unknown) => thing is InjectionToken<unknown, unknown>;
 
 export function createContainer(
   containerId: string,

--- a/packages/injectable/core/index.test-d.ts
+++ b/packages/injectable/core/index.test-d.ts
@@ -16,6 +16,8 @@ import {
   createInjectionTargetDecorator,
   SpecificInject,
   InjectionToken,
+  isInjectable,
+  isInjectionToken,
 } from '.';
 
 const di = createContainer('some-container');
@@ -44,6 +46,16 @@ const decoratorForToken = getInjectable({
 
   injectionToken: instantiationDecoratorToken,
 });
+
+const foo: unknown = "number";
+
+if (isInjectable(foo)) {
+  expectType<Injectable<unknown, unknown, unknown>>(foo);
+}
+
+if (isInjectionToken(foo)) {
+  expectType<InjectionToken<unknown, unknown>>(foo);
+}
 
 // given injectable without instantiation paramater and decorator targeting the injectable, typing is ok
 const someInjectableToBeDecorated = getInjectable({

--- a/packages/injectable/core/index.test-d.ts
+++ b/packages/injectable/core/index.test-d.ts
@@ -57,6 +57,9 @@ if (isInjectionToken(foo)) {
   expectType<InjectionToken<unknown, unknown>>(foo);
 }
 
+const x1: boolean = isInjectable(foo);
+const x2: boolean = isInjectionToken(foo);
+
 // given injectable without instantiation paramater and decorator targeting the injectable, typing is ok
 const someInjectableToBeDecorated = getInjectable({
   id: 'some-injectable-to-be-decorated',


### PR DESCRIPTION
This is 100% backwards compatible since `thing is T` is actually a boolean under the hood and coerces as expected.