### PR TITLE
fix(injectable-extension-for-mobx): ComputedInjectMaybe should pass through injection params

### DIFF
--- a/packages/injectable/extension-for-mobx/src/computedInjectMaybe.js
+++ b/packages/injectable/extension-for-mobx/src/computedInjectMaybe.js
@@ -2,6 +2,7 @@ import { computed } from 'mobx';
 import {
   getInjectable,
   getInjectionToken,
+  getKeyedSingletonCompositeKey,
   lifecycleEnum,
 } from '@ogre-tools/injectable';
 import { computedInjectManyWithMetaInjectionToken } from './computedInjectMany';
@@ -13,11 +14,14 @@ export const computedInjectMaybeInjectionToken = getInjectionToken({
 export const _computedInjectMaybeInjectable = getInjectable({
   id: 'computed-inject-maybe-internal',
 
-  instantiate: (di, token) =>
-    computed(() => {
-      const [value = undefined, ...collidingValues] = di
-        .inject(computedInjectManyWithMetaInjectionToken)(token)
-        .get();
+  instantiate: (di, { token, param }) => {
+    const computedInjectManyWithMeta = di.inject(
+      computedInjectManyWithMetaInjectionToken,
+    );
+    const computedMany = computedInjectManyWithMeta(token, param);
+
+    return computed(() => {
+      const [value, ...collidingValues] = computedMany.get();
 
       if (collidingValues.length) {
         throw new Error(
@@ -31,15 +35,18 @@ export const _computedInjectMaybeInjectable = getInjectable({
       }
 
       return value?.instance;
-    }),
+    });
+  },
 
   lifecycle: lifecycleEnum.keyedSingleton({
-    getInstanceKey: (_, injectionToken) => injectionToken,
+    getInstanceKey: (_, { token, param }) =>
+      getKeyedSingletonCompositeKey(token, param),
   }),
 });
 
 export const computedInjectMaybeInjectable = getInjectable({
   id: 'computed-inject-maybe',
-  instantiate: di => token => di.inject(_computedInjectMaybeInjectable, token),
+  instantiate: di => (token, param) =>
+    di.inject(_computedInjectMaybeInjectable, { token, param }),
   injectionToken: computedInjectMaybeInjectionToken,
 });

--- a/packages/injectable/extension-for-mobx/src/computedInjectMaybeWithInstantiationParameter.test.js
+++ b/packages/injectable/extension-for-mobx/src/computedInjectMaybeWithInstantiationParameter.test.js
@@ -1,0 +1,195 @@
+import { noop } from 'lodash/fp';
+import { autorun, configure, runInAction, onReactionError } from 'mobx';
+
+import {
+  createContainer,
+  getInjectable,
+  getInjectionToken,
+  injectionDecoratorToken,
+  lifecycleEnum,
+} from '@ogre-tools/injectable';
+
+import { computedInjectMaybeInjectionToken } from './computedInjectMaybe';
+
+import { registerMobX } from './registerMobx';
+import { isPromise } from '@ogre-tools/fp';
+
+describe('computedInjectMaybe with instantiation parameter', () => {
+  let actualObservedInstance;
+
+  beforeEach(() => {
+    configure({
+      enforceActions: 'always',
+      computedRequiresReaction: true,
+      reactionRequiresObservable: true,
+      observableRequiresReaction: true,
+    });
+  });
+
+  describe('given there is injection token and implementations of it, when injected as reactive', () => {
+    let di;
+    let actual;
+    let someInjectionToken;
+    let someCollidingInjectable;
+    let actualObservationsCount;
+    let someInjectable;
+    let contextsOfSomeInjectable;
+
+    beforeEach(() => {
+      contextsOfSomeInjectable = [];
+      actualObservationsCount = 0;
+
+      someInjectionToken = getInjectionToken({
+        id: 'some-injection-token',
+      });
+
+      someInjectable = getInjectable({
+        id: 'some-injectable',
+        instantiate: (_, id) => `some-instance-for(${id})`,
+        injectionToken: someInjectionToken,
+        lifecycle: lifecycleEnum.keyedSingleton({
+          getInstanceKey: (_, id) => id,
+        }),
+      });
+
+      const contextSpyDecorator = getInjectable({
+        id: 'context-spy-decorator',
+
+        instantiate: () => ({
+          target: someInjectable,
+
+          decorate:
+            toBeDecorated =>
+            (alias, instantiationParameter, context = []) => {
+              contextsOfSomeInjectable.push([
+                ...context.map(x => x.injectable.id),
+                alias.id,
+              ]);
+
+              return toBeDecorated(alias, instantiationParameter, context);
+            },
+        }),
+
+        decorable: false,
+
+        injectionToken: injectionDecoratorToken,
+      });
+
+      someCollidingInjectable = getInjectable({
+        id: 'some-colliding-injectable',
+        instantiate: (_, id) => `some-colliding-instance-for(${id})`,
+        injectionToken: someInjectionToken,
+        lifecycle: lifecycleEnum.keyedSingleton({
+          getInstanceKey: (_, id) => id,
+        }),
+      });
+
+      di = createContainer('some-container');
+
+      di.register(contextSpyDecorator);
+
+      registerMobX(di);
+    });
+
+    describe('given in reactive context and observed as computedInjectMaybe, when no injectables that implement the injection token are registered', () => {
+      beforeEach(() => {
+        const computedInjectMaybe = di.inject(
+          computedInjectMaybeInjectionToken,
+        );
+
+        actual = computedInjectMaybe(someInjectionToken, 'some-param');
+
+        autorun(() => {
+          actualObservedInstance = actual.get();
+          actualObservationsCount++;
+        });
+      });
+
+      it('injects no instance, as there is none registered', () => {
+        expect(actualObservedInstance).toBeUndefined();
+      });
+
+      it('causes only one reaction', () => {
+        expect(actualObservationsCount).toBe(1);
+      });
+
+      it('when injected again with the same param, returns same instance of computed', () => {
+        const computedInjectMaybe = di.inject(
+          computedInjectMaybeInjectionToken,
+        );
+
+        const actual1 = computedInjectMaybe(someInjectionToken, 'some-param');
+        const actual2 = computedInjectMaybe(someInjectionToken, 'some-param');
+
+        expect(actual1).toBe(actual2);
+      });
+
+      it('when injected again with a different param, returns different instance of computed', () => {
+        const computedInjectMaybe = di.inject(
+          computedInjectMaybeInjectionToken,
+        );
+
+        const actual1 = computedInjectMaybe(someInjectionToken, 'some-param');
+        const actual2 = computedInjectMaybe(
+          someInjectionToken,
+          'some-other-param',
+        );
+
+        expect(actual1).not.toBe(actual2);
+      });
+
+      describe('when an implementation gets registered', () => {
+        beforeEach(() => {
+          runInAction(() => {
+            di.register(someInjectable);
+          });
+        });
+
+        it('the instance is observed', () => {
+          expect(actualObservedInstance).toBe('some-instance-for(some-param)');
+        });
+
+        it('when the implementation gets deregistered, instance is no longer observed', () => {
+          runInAction(() => {
+            di.deregister(someInjectable);
+          });
+
+          expect(actualObservedInstance).toBeUndefined();
+        });
+
+        describe('when a colliding implementation for the token gets registered', () => {
+          let actualError;
+
+          beforeEach(() => {
+            onReactionError((error, reaction) => {
+              actualError = error.message;
+            });
+
+            withSuppressedConsoleError(() => {
+              runInAction(() => {
+                di.register(someCollidingInjectable);
+              });
+            });
+          });
+
+          it('an error is thrown', () => {
+            expect(actualError).toBe(
+              'Tried to computedInjectMaybe "some-injection-token", but more than one contribution was encountered: "some-injectable", "some-colliding-injectable"',
+            );
+          });
+        });
+      });
+    });
+  });
+});
+
+const withSuppressedConsoleError = toBeSuppressed => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+  const supressed = toBeSuppressed();
+
+  if (isPromise(supressed)) {
+    supressed.finally(() => consoleErrorSpy.mockRestore());
+  } else {
+    consoleErrorSpy.mockRestore();
+  }
+};


### PR DESCRIPTION
## Summary

- Fix `computedInjectMaybe` to properly pass through instantiation parameters
- Use `getKeyedSingletonCompositeKey` to correctly cache computed instances by both token and param
- Add comprehensive test suite for `computedInjectMaybe` with instantiation parameters

Cherry-picked from lensapp/ogre-tools (PR merged to origin/master after the initial upstream sync).

## Test plan

- [x] All 764 tests pass (71 suites)
- [x] Type tests pass
- [x] Code style verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)