### PR TITLE
Sync recent commits from upstream: getPropsFromPlugins + getInjectable2 narrowing fix

### DIFF
--- a/packages/element-component/index.ts
+++ b/packages/element-component/index.ts
@@ -6,7 +6,11 @@ export {
 
 export { getPlugin, Plugin } from './src/plugin/plugin';
 
-export type { WrapperEntry } from './src/_private/run-plugins';
+export { getPropsFromPlugins } from './src/get-props-from-plugins';
+export type {
+  PluginsResult,
+  WrapperEntry,
+} from './src/get-props-from-plugins';
 
 export type ContributeRef = (
   refCallback: (node: HTMLElement | null) => void,

--- a/packages/element-component/src/element-component.test.tsx
+++ b/packages/element-component/src/element-component.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ComponentType } from 'react';
 import { getElementComponent } from './element-component';
 import { RenderResult } from '@testing-library/react';
 import { render } from '@testing-library/react';
@@ -6,6 +7,11 @@ import { render } from '@testing-library/react';
 import { Discover, discoverFor } from '@ogre-tools/discoverable';
 
 import { getPlugin, Plugin } from './plugin/plugin';
+import {
+  getPropsFromPlugins,
+  PluginsResult,
+  WrapperEntry,
+} from './get-props-from-plugins';
 import { useEffect, useRef } from 'react';
 
 describe('element', () => {
@@ -814,5 +820,108 @@ describe('element', () => {
         discover.getSingleElement('wrapper');
       }).not.toThrow();
     });
+  });
+});
+
+describe('getPropsFromPlugins', () => {
+  const assertType = <T,>(_value: T): void => undefined;
+
+  it('given no plugins, when called, runs the chain', () => {
+    const result = getPropsFromPlugins({ title: 'x' });
+
+    expect(result.props).toEqual({ title: 'x' });
+    expect(result.refs).toEqual([]);
+    expect(result.wrappers).toEqual([]);
+  });
+
+  it('given a prop-transforming plugin, when called, returns transformed props', () => {
+    const somePlugin = getPlugin<{ $somePluginProp: string }>(
+      ({ $somePluginProp }) => ({
+        className: $somePluginProp,
+        $somePluginProp: undefined,
+      }),
+    );
+
+    const result = getPropsFromPlugins(
+      { $somePluginProp: 'some-value' },
+      somePlugin,
+    );
+
+    expect(result.props).toEqual({ className: 'some-value' });
+  });
+
+  it('typing: no-plugins overload preserves TProps on result.props', () => {
+    const result = getPropsFromPlugins({ title: 'x', $foo: 1 });
+
+    assertType<PluginsResult<{ title: string; $foo: number }>>(result);
+    assertType<{ title: string; $foo: number }>(result.props);
+  });
+
+  it('typing: with-plugins overload accepts plugin-tuple-derived input shape', () => {
+    const somePlugin = getPlugin<{ $somePluginProp: string }>(
+      ({ $somePluginProp }) => ({
+        className: $somePluginProp,
+        $somePluginProp: undefined,
+      }),
+    );
+
+    const result = getPropsFromPlugins(
+      { $somePluginProp: 'some-value' },
+      somePlugin,
+    );
+
+    assertType<PluginsResult>(result);
+    assertType<WrapperEntry[]>(result.wrappers);
+  });
+
+  it('typing: with-plugins overload rejects input missing required plugin prop', () => {
+    const somePlugin = getPlugin<{ $somePluginProp: string }>(
+      ({ $somePluginProp }) => ({
+        className: $somePluginProp,
+        $somePluginProp: undefined,
+      }),
+    );
+
+    // @ts-expect-error — $somePluginProp is required
+    void getPropsFromPlugins({}, somePlugin);
+  });
+
+  it('typing: with-plugins overload rejects wrong-typed plugin-prop value', () => {
+    const somePlugin = getPlugin<{ $somePluginProp: number }>(() => ({
+      $somePluginProp: undefined,
+    }));
+
+    void getPropsFromPlugins(
+      // @ts-expect-error — value must be a number
+      { $somePluginProp: 'not-a-number' },
+      somePlugin,
+    );
+  });
+
+  it('typing: WrapperEntry is generic-friendly with default and narrowed variants', () => {
+    const defaultWrapper: WrapperEntry = {
+      Component: (() => null) as ComponentType<any>,
+      props: { foo: 'bar' },
+    };
+
+    assertType<WrapperEntry>(defaultWrapper);
+
+    const TypedWrapperComponent: ComponentType<{ label: string }> = ({
+      label,
+    }) => <span>{label}</span>;
+
+    const typedWrapper: WrapperEntry<{ label: string }> = {
+      Component: TypedWrapperComponent,
+      props: { label: 'x' },
+    };
+
+    assertType<WrapperEntry<{ label: string }>>(typedWrapper);
+
+    // @ts-expect-error — props.label must be a string
+    const _badWrapper: WrapperEntry<{ label: string }> = {
+      Component: TypedWrapperComponent,
+      props: { label: 1 },
+    };
+    void _badWrapper;
   });
 });

--- a/packages/element-component/src/element-component.tsx
+++ b/packages/element-component/src/element-component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { forwardRef, JSX, MutableRefObject, Ref } from 'react';
 import { Plugin, PropsFromPluginTuple } from './plugin/plugin';
-import { runPlugins } from './_private/run-plugins';
+import { getPropsFromPlugins } from './get-props-from-plugins';
 
 export type TagNames = keyof JSX.IntrinsicElements;
 
@@ -34,7 +34,7 @@ export function getElementComponent<TagName extends TagNames>(
         props: processedProps,
         refs,
         wrappers,
-      } = runPlugins(unprocessedProps, plugins);
+      } = getPropsFromPlugins(unprocessedProps, ...plugins);
 
       const wrapperRefContributions = React.useRef<
         ((node: HTMLElement | null) => void)[]

--- a/packages/element-component/src/get-props-from-plugins.ts
+++ b/packages/element-component/src/get-props-from-plugins.ts
@@ -1,28 +1,37 @@
 import { ComponentType, MutableRefObject } from 'react';
-import { Plugin } from '../plugin/plugin';
+import { Plugin, PropsFromPluginTuple } from './plugin/plugin';
 
 type RefCallback<T> = (instance: T | null) => void;
 type Ref<T> = RefCallback<T> | MutableRefObject<T | null> | null;
 
-export type WrapperEntry = {
-  Component: ComponentType<any>;
-  props: Record<string, unknown>;
+export type WrapperEntry<
+  TProps extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  Component: ComponentType<TProps>;
+  props: TProps;
 };
 
-interface PluginResult {
-  props: Record<string, unknown>;
+export interface PluginsResult<
+  TProps extends Record<string, unknown> = Record<string, unknown>,
+> {
+  props: TProps;
   refs: Ref<HTMLElement>[];
   wrappers: WrapperEntry[];
 }
 
-/**
- * Runs all plugins in a single pass, collecting refs, wrappers, and merging props.
- * Plugins can set props to undefined to remove them from the output.
- */
-export const runPlugins = (
+export function getPropsFromPlugins<TProps extends Record<string, unknown>>(
+  initialProps: TProps,
+): PluginsResult<TProps>;
+
+export function getPropsFromPlugins<PluginTuple extends readonly Plugin<any>[]>(
+  initialProps: PropsFromPluginTuple<PluginTuple>,
+  ...plugins: PluginTuple
+): PluginsResult;
+
+export function getPropsFromPlugins(
   initialProps: Record<string, unknown>,
-  plugins: Plugin<Record<string, unknown>, Record<string, unknown>>[],
-): PluginResult => {
+  ...plugins: Plugin<Record<string, unknown>, Record<string, unknown>>[]
+): PluginsResult {
   let currentProps = initialProps;
   const collectedRefs: Ref<HTMLElement>[] = [];
   const collectedWrappers: WrapperEntry[] = [];
@@ -30,7 +39,6 @@ export const runPlugins = (
   for (const plugin of plugins) {
     const output = plugin(currentProps) as Record<string, unknown>;
 
-    // Handle ref collection
     const ref = output.ref as Ref<HTMLElement> | undefined;
     if (ref !== undefined) {
       if (ref !== null) {
@@ -39,21 +47,18 @@ export const runPlugins = (
       output.ref = undefined;
     }
 
-    // Handle $wrapper collection
     const wrapper = output.$wrapper as WrapperEntry | undefined;
     if (wrapper !== undefined) {
       collectedWrappers.push(wrapper);
       output.$wrapper = undefined;
     }
 
-    // Merge input props into output (output takes precedence)
     for (const key in currentProps) {
       if (!(key in output)) {
         output[key] = currentProps[key];
       }
     }
 
-    // Remove undefined values (plugins set props to undefined to clean them up)
     for (const key in output) {
       if (output[key] === undefined) {
         delete output[key];
@@ -68,4 +73,4 @@ export const runPlugins = (
     refs: collectedRefs,
     wrappers: collectedWrappers,
   };
-};
+}

--- a/packages/injectable/core/index.d.ts
+++ b/packages/injectable/core/index.d.ts
@@ -583,17 +583,37 @@ export interface Injectable2<F extends Factory = Factory> {
   readonly aliasType: 'injectable2';
   readonly id: string;
   readonly instantiate: (di: DiContainerForInjection2) => F;
-  readonly injectionToken?: InjectionToken2<F>;
+  // Stored at the wider Factory shape so an injectable's F can stay narrower
+  // than its token's F. The construction-time `F extends TF` constraint on
+  // `getInjectable2` keeps the relationship sound; precise per-injectable
+  // token typing isn't observably useful here (runtime reads only token-level
+  // fields like `.id`, `.abstract`, `.maxCacheSize`).
+  readonly injectionToken?: InjectionToken2<Factory>;
   readonly transient?: boolean;
   readonly causesSideEffects?: boolean;
   readonly tags?: string[];
   readonly maxCacheSize?: number;
 }
 
+// With injectionToken: F is the injectable's actual factory (kept narrow so
+// `di.inject2(injectable)` returns the narrow factory), TF is the token's
+// factory contract. The `F extends TF` constraint verifies the implementation
+// satisfies the contract.
+export function getInjectable2<F extends TF, TF extends Factory>(options: {
+  readonly id: string;
+  readonly instantiate: (di: DiContainerForInjection2) => F;
+  readonly injectionToken: InjectionToken2<TF>;
+  readonly transient?: boolean;
+  readonly causesSideEffects?: boolean;
+  readonly tags?: string[];
+  readonly maxCacheSize?: number;
+}): Injectable2<F>;
+
+// Without injectionToken: infer F from instantiate, so callers of di.inject /
+// useInject / useInject2 still get precise parameter and return types.
 export function getInjectable2<F extends Factory>(options: {
   readonly id: string;
   readonly instantiate: (di: DiContainerForInjection2) => F;
-  readonly injectionToken?: InjectionToken2<F>;
   readonly transient?: boolean;
   readonly causesSideEffects?: boolean;
   readonly tags?: string[];

--- a/packages/injectable/core/index.test-d.ts
+++ b/packages/injectable/core/index.test-d.ts
@@ -888,6 +888,86 @@ const handlerImpl = getInjectable2({
   instantiate: () => () => 'hello',
 });
 
+// --- getInjectable2: injectionToken accepts a narrower implementation ---
+
+// Repro for the inference defect where TS used to reject a wider
+// injectionToken against an inline factory literal of narrower shape. The
+// implementation must keep its narrow F (so direct-injectable injection
+// returns the narrow factory) while the token's wider contract is enforced.
+
+interface BroadComponent {
+  (): unknown;
+}
+
+interface NarrowComponent extends BroadComponent {
+  readonly __narrow: 'narrow';
+}
+
+interface Item {
+  Component: BroadComponent;
+  orderNumber: number;
+}
+
+const itemToken2 = getInjectionToken2<() => Item>({ id: 'item' });
+
+declare const myNarrowComponent: NarrowComponent;
+
+const myItemImpl = getInjectable2({
+  id: 'my-item',
+  injectionToken: itemToken2,
+  instantiate: () => () => ({
+    Component: myNarrowComponent,
+    orderNumber: 50,
+  }),
+});
+
+// Direct-injectable injection preserves the narrower factory return shape.
+expectType<NarrowComponent>(di.inject2(myItemImpl)().Component);
+
+// Token injection returns the wider contract.
+expectType<BroadComponent>(di.inject2(itemToken2)().Component);
+
+// A factory genuinely incompatible with the token is still a type error.
+expectError(
+  getInjectable2({
+    id: 'wrong-shape',
+    injectionToken: itemToken2,
+    instantiate: () => () => ({ wrong: true }),
+  }),
+);
+
+// --- getInjectable (v1): same narrow-vs-wide behavior at inject sites ---
+
+// Same Item / NarrowComponent / BroadComponent fixtures, v1 API: the token's
+// generic is the instance type (not a factory) and `di.inject` returns the
+// instance directly.
+
+const itemToken1 = getInjectionToken<Item>({ id: 'item-1' });
+
+const myItemImpl1 = getInjectable({
+  id: 'my-item-1',
+  injectionToken: itemToken1,
+  instantiate: () => ({
+    Component: myNarrowComponent,
+    orderNumber: 50,
+  }),
+});
+
+// Direct-injectable injection preserves the narrower instance shape.
+expectType<NarrowComponent>(di.inject(myItemImpl1).Component);
+
+// Token injection returns the wider contract.
+expectType<BroadComponent>(di.inject(itemToken1).Component);
+
+// An instance genuinely incompatible with the token is still a type error.
+expectError(
+  getInjectable({
+    id: 'wrong-shape-1',
+    injectionToken: itemToken1,
+    instantiate: () => ({ wrong: true }),
+  }),
+);
+
 // --- DiContainerForInjection2: inject2 returns factories inside new-style instantiate ---
 
 const innerInjectable2 = getInjectable2({
@@ -1146,7 +1226,10 @@ expectError(di.override2(userServiceToken2, () => userId => ({ userId })));
 
 // earlyOverride2 carries the same injectable2 typing
 expectType<void>(
-  di.earlyOverride2(parametricInjectable2, () => (name, age) => ({ name, age })),
+  di.earlyOverride2(parametricInjectable2, () => (name, age) => ({
+    name,
+    age,
+  })),
 );
 expectError(
   di.earlyOverride2(parametricInjectable2, () => (name, age) => ({
@@ -1212,12 +1295,12 @@ const generalBrandedWrapperToken2 = getInjectionToken2<
   >
 >({ id: 'general-branded-wrapper' });
 
-const primaryBrandSpecifier = getTypedSpecifier<{ brand: 'primary' }>()(
-  'primary-brand',
-);
+const primaryBrandSpecifier =
+  getTypedSpecifier<{ brand: 'primary' }>()('primary-brand');
 
-const primaryWrapperToken =
-  generalBrandedWrapperToken2.for(primaryBrandSpecifier);
+const primaryWrapperToken = generalBrandedWrapperToken2.for(
+  primaryBrandSpecifier,
+);
 
 // `.for(specifier)` yields a token whose factory has `brand` pinned to 'primary'
 // while `T` remains free.
@@ -1254,26 +1337,18 @@ expectError(
 
 // Override of the specifier-produced token preserves both brand and `T`
 expectType<void>(
-  di.override2(
-    primaryWrapperToken,
-    () =>
-      <T>(value: T) => ({
-        wrapped: value,
-        brand: 'primary' as const,
-      }),
-  ),
+  di.override2(primaryWrapperToken, () => <T>(value: T) => ({
+    wrapped: value,
+    brand: 'primary' as const,
+  })),
 );
 
 // Override with the wrong brand fails the specifier-fixed type
 expectError(
-  di.override2(
-    primaryWrapperToken,
-    () =>
-      <T>(value: T) => ({
-        wrapped: value,
-        brand: 'secondary' as const,
-      }),
-  ),
+  di.override2(primaryWrapperToken, () => <T>(value: T) => ({
+    wrapped: value,
+    brand: 'secondary' as const,
+  })),
 );
 
 // unoverride accepts injectable2 and token2
@@ -1306,12 +1381,16 @@ expectError(instancePurgeCallbackToken.for(someOldStyleTokenForPurge));
 getInjectable2({
   id: 'purge-callback-for-parametric-2',
   injectionToken: instancePurgeCallbackToken.for(parametricInjectable2),
-  instantiate: () => () => ({ instance }) => (name, age) => {
-    expectType<{ name: string; age: number }>(instance);
-    expectType<string>(name);
-    expectType<number>(age);
-    return { name, age };
-  },
+  instantiate:
+    () =>
+    () =>
+    ({ instance }) =>
+    (name, age) => {
+      expectType<{ name: string; age: number }>(instance);
+      expectType<string>(name);
+      expectType<number>(age);
+      return { name, age };
+    },
 });
 
 // Wrong inner arrow arg type → type error
@@ -1320,7 +1399,8 @@ expectError(
     id: 'purge-callback-wrong-arg',
     injectionToken: instancePurgeCallbackToken.for(parametricInjectable2),
     instantiate:
-      () => () =>
+      () =>
+      () =>
       ({ instance }) =>
       (name: number, age) => ({
         name: String(name),
@@ -1334,10 +1414,14 @@ expectError(
   getInjectable2({
     id: 'purge-callback-wrong-return',
     injectionToken: instancePurgeCallbackToken.for(parametricInjectable2),
-    instantiate: () => () => ({ instance }) => (name, age) => ({
-      name,
-      age: String(age),
-    }),
+    instantiate:
+      () =>
+      () =>
+      ({ instance }) =>
+      (name, age) => ({
+        name,
+        age: String(age),
+      }),
   }),
 );
 
@@ -1345,10 +1429,14 @@ expectError(
 getInjectable2({
   id: 'purge-callback-for-nonparametric-2',
   injectionToken: instancePurgeCallbackToken.for(nonParametricInjectable2),
-  instantiate: () => () => ({ instance }) => () => {
-    expectType<number>(instance);
-    return 0;
-  },
+  instantiate:
+    () =>
+    () =>
+    ({ instance }) =>
+    () => {
+      expectType<number>(instance);
+      return 0;
+    },
 });
 
 // --- injectable2 target: injection token2 ---
@@ -1356,11 +1444,15 @@ getInjectable2({
 getInjectable2({
   id: 'purge-callback-for-user-service-token-2',
   injectionToken: instancePurgeCallbackToken.for(userServiceToken2),
-  instantiate: () => () => ({ instance }) => userId => {
-    expectType<{ id: string }>(instance);
-    expectType<string>(userId);
-    return { id: userId };
-  },
+  instantiate:
+    () =>
+    () =>
+    ({ instance }) =>
+    userId => {
+      expectType<{ id: string }>(instance);
+      expectType<string>(userId);
+      return { id: userId };
+    },
 });
 
 // --- generic factory target preserves T on the inner arrow ---
@@ -1369,7 +1461,8 @@ getInjectable2({
   id: 'purge-callback-for-wrapper-token',
   injectionToken: instancePurgeCallbackToken.for(wrapperToken2),
   instantiate:
-    () => () =>
+    () =>
+    () =>
     ({ instance }) =>
     <T>(value: T) => ({ wrapped: value }),
 });
@@ -1380,7 +1473,8 @@ expectError(
     id: 'purge-callback-wrapper-bad-t',
     injectionToken: instancePurgeCallbackToken.for(wrapperToken2),
     instantiate:
-      () => () =>
+      () =>
+      () =>
       ({ instance }) =>
       <T>(value: T) => ({ wrapped: value.toUpperCase() }),
   }),
@@ -1402,12 +1496,16 @@ expectError(
 
 // ---- AbstractInjectionToken2 ----
 
-const abstractHandlerToken = getAbstractInjectionToken2<(name: string) => void>({
-  id: 'abstract-handler',
-});
+const abstractHandlerToken = getAbstractInjectionToken2<(name: string) => void>(
+  {
+    id: 'abstract-handler',
+  },
+);
 
 // abstract token has correct type
-expectType<AbstractInjectionToken2<(name: string) => void>>(abstractHandlerToken);
+expectType<AbstractInjectionToken2<(name: string) => void>>(
+  abstractHandlerToken,
+);
 
 // .for() returns a non-abstract SpecificInjectionToken2
 const specificFromAbstract = abstractHandlerToken.for('click');
@@ -1431,11 +1529,13 @@ expectType<InjectionInstanceWithMeta<void>[]>(
 );
 
 // implementing abstract token directly is a TYPE ERROR
-expectError(getInjectable2({
-  id: 'bad-impl',
-  injectionToken: abstractHandlerToken,
-  instantiate: () => (name: string) => {},
-}));
+expectError(
+  getInjectable2({
+    id: 'bad-impl',
+    injectionToken: abstractHandlerToken,
+    instantiate: () => (name: string) => {},
+  }),
+);
 
 // implementing specific token from abstract is OK
 getInjectable2({


### PR DESCRIPTION
## Summary

Cherry-picks two recent commits from upstream (`origin/master`) that aren't yet in `ogre-works/master`. Discoverable import was auto-merged to `@ogre-tools/discoverable`; no other rebrand changes were needed.

- **`feat(element-component): Expose getPropsFromPlugins so non-React callers can derive element props`** — Promotes the private plugin chain runner (`src/_private/run-plugins.ts`) to a public `getPropsFromPlugins` in `src/get-props-from-plugins.ts`. Makes `WrapperEntry` / `PluginsResult` generic with `Record<string, unknown>` defaults so existing consumers stay source-compatible. Adds a test block covering the no-plugins overload, the with-plugins overload, plugin-prop typing, and the generic `WrapperEntry`.
- **`fix(injectable): Let getInjectable2 implementation be narrower than its token`** — Splits `getInjectable2` into a token overload `<F extends TF, TF extends Factory>` and a tokenless overload. An implementation's `F` can now stay narrower than the token's `TF` (enforced by `F extends TF`), so `di.inject2(injectable)` returns the narrow factory while `di.inject2(token)` returns the wider contract. `Injectable2.injectionToken` widens to `InjectionToken2<Factory>` since the per-injectable `F` was not observably useful. Adds v1 + v2 type tests for the narrowing behavior plus negative cases.

## Skipped from upstream

- `chore: Fix build-and-publish to build packages before running tests` — the build-before-test fix is already present in ogre-works in a different shape; cherry-picking would be churn.
- Upstream `chore(release): v22.x` bumps — ogre-works is on its own v23 release line.

## Test plan
- [ ] CI: code-style:verify across the workspace
- [ ] CI: full Jest test suite
- [ ] `cd packages/injectable/core && npx tsd` passes (verified locally before push)
- [ ] `cd packages/injectable/react && npm run test:types` passes (verified locally before push)
- [ ] Reviewer: confirm the auto-merged `@ogre-tools/discoverable` import in `element-component.test.tsx` is correct
- [ ] Reviewer: spot-check downstream consumers (if any) that read `.injectionToken` off an `Injectable2<F>` and rely on its precise `F` — the stored type is now `InjectionToken2<Factory>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)